### PR TITLE
fix: add comment in boilerplate denoting click's intended way of exiting with a custom exit code

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.pkg_name }}.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.pkg_name }}.py
@@ -11,8 +11,10 @@ import click
 
 {% if cookiecutter.command_line_interface|lower == 'click' %}
 @click.command()
-def main() -> int:
-    return 0
+def main() -> None:
+    # NOTE: click does not pass on the return value of the function.
+    # use `raise SystemExit(return_code)` yourself where necessary
+    pass
 {%- endif %}
 {%- if cookiecutter.command_line_interface|lower == 'argparse' %}
 def main(argv: Sequence[str] | None = None):
@@ -24,4 +26,8 @@ def main(argv: Sequence[str] | None = None):
 
 
 if __name__ == "__main__":
+{% if cookiecutter.command_line_interface|lower == 'click' %}
+    main()
+{%- else %}
     raise SystemExit(main())
+{%- endif %}


### PR DESCRIPTION
Closes #22 