### PR TITLE
ci: make all docker jobs depent on trivy-security passing

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/docker.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Docker Image Build / Scan / Sync
+name: Docker Image Scan / Build / README
 
 "on":
   push:
@@ -23,7 +23,39 @@ name: Docker Image Build / Scan / Sync
       - "master"
 
 jobs:
+  trivy-security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - name: set up qemu for docker
+        uses: docker/setup-qemu-action@v2
+
+      - name: set up docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build Dockerfile.
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          load: true
+          tags: "{{ cookiecutter.dockerhub_username }}/{{ cookiecutter.project_slug }}:local"
+
+      - name: Run Trivy vulnerability scanner on built Image.
+        uses: aquasecurity/trivy-action@0.2.5
+        with:
+          image-ref: "{{ cookiecutter.dockerhub_username }}/{{ cookiecutter.project_slug }}:local"
+          format: table
+          exit-code: "1"
+          # relevant read: https://pythonspeed.com/articles/docker-security-scanner/
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"
+
   dockerhub:
+    needs: trivy-security
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase.
@@ -66,38 +98,8 @@ jobs:
           tags: {% raw %}${{ steps.meta.outputs.tags }}{% endraw %}
           labels: {% raw %}${{ steps.meta.outputs.labels }}{% endraw %}
 
-  trivy-security:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v3
-
-      - name: set up qemu for docker
-        uses: docker/setup-qemu-action@v2
-
-      - name: set up docker buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build Dockerfile.
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
-          load: true
-          tags: "{{ cookiecutter.dockerhub_username }}/{{ cookiecutter.project_slug }}:local"
-
-      - name: Run Trivy vulnerability scanner on built Image.
-        uses: aquasecurity/trivy-action@0.2.5
-        with:
-          image-ref: "{{ cookiecutter.dockerhub_username }}/{{ cookiecutter.project_slug }}:local"
-          format: table
-          exit-code: "1"
-          # relevant read: https://pythonspeed.com/articles/docker-security-scanner/
-          ignore-unfixed: true
-          vuln-type: "os,library"
-          severity: "CRITICAL,HIGH"
-
   dockerhub-readme:
+    needs: dockerhub
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase.


### PR DESCRIPTION
this seems the obvious way to do. don't fire-and-regret (mildly bad) / forget (fucking bad)