### PR TITLE
ci: create codeql analysis workflow

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/codeql-analysis.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+"on":
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    # At 01:30 AM on Sunday
+    - cron: "30 1 * * 0"
+
+jobs:
+  CodeQL-Analysis:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # required for all workflows:
+      security-events: write
+      # required for workflows in private repositories:
+      actions: read
+      contents: read
+
+    steps:
+      - name: check out the codebase
+        uses: actions/checkout@v3
+
+      - name: set up python in minimum required version
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.7"
+
+      - name: install dependencies
+        run: |
+          python -m pip install -r requirements-dev.txt
+          python -m pip install -r requirements.txt
+          echo "CODEQL_PYTHON=$(which python)" >> $GITHUB_ENV
+
+      - name: Initialize CodeQL.
+        uses: github/codeql-action/init@v2
+        with:
+          languages: python
+          # https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#analyzing-python-dependencies
+          setup-python-dependencies: false
+
+      # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually.
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      - name: Perform CodeQL Analysis.
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
copied base from JonasPammer/cookiecutter-github-action-typescript which used the recommended template

adapted to use own python dependencies resoultion (without it would've guessingly just pip installed local setup.cfg, with this it uses pinned versions)