### PR TITLE
ci: exclude pip-compile'd files from renovate

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/renovate.json5
+++ b/{{ cookiecutter.project_slug }}/.github/renovate.json5
@@ -35,6 +35,9 @@
   lockFileMaintenance: { enabled: true },
   stabilityDays: 7,
 
+  // https://github.com/JonasPammer/ansible-roles/issues/46
+  ignorePaths: ["requirements*.txt", "setup.cfg"],
+
   commitMessageTopic: "{% raw %}{{manager}} dependency {{depName}}{% endraw %}",
   labels: ["kind/dependencies"],
   packageRules: [


### PR DESCRIPTION
Fixes #115

lgtm! https://github.com/JonasPammer/ansible-roles/issues/46#issuecomment-1527562734