### PR TITLE
ci(docker): run pip upgrade before inside venv

### DIFF
--- a/{{ cookiecutter.project_slug }}/Dockerfile
+++ b/{{ cookiecutter.project_slug }}/Dockerfile
@@ -20,7 +20,8 @@ ENV PYTHONDONTWRITEBYTECODE=1
 RUN apt-get -qy update \
     && apt-get -qqy install --no-install-recommends python3-wheel \
     && python3 -m pip install --no-cache-dir --upgrade pip \
-    && python3 -m pip install --no-cache-dir --upgrade setuptools wheel \
+    && python3 -m pip install --no-cache-dir --upgrade setuptools \
+    && python3 -m pip install --no-cache-dir --upgrade wheel \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for security purposes
@@ -36,7 +37,10 @@ ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 RUN chown -R "${DOCKER_APP_USER}:${DOCKER_APP_USER}" /app
 USER ${DOCKER_APP_USER}
-
+RUN true \
+    && python3 -m pip install --no-cache-dir --upgrade pip \
+    && python3 -m pip install --no-cache-dir --upgrade setuptools \
+    && python3 -m pip install --no-cache-dir --upgrade wheel
 
 ### Project-Specific Dockerfile Steps ###
 WORKDIR /app

--- a/{{ cookiecutter.project_slug }}/Dockerfile
+++ b/{{ cookiecutter.project_slug }}/Dockerfile
@@ -9,12 +9,18 @@ ARG VIRTUAL_ENV=/app/venv
 ### General Python Debian Docker Best-Practice Preperation Steps ###
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
-ENV PYTHONUNBUFFERED=1
-ENV PYTHONDONTWRITEBYTECODE=1
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -qy update \
     && apt-get -qy upgrade \
     && apt-get -qy install --no-install-recommends apt-utils tini \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+RUN apt-get -qy update \
+    && apt-get -qqy install --no-install-recommends python3-wheel \
+    && python3 -m pip install --no-cache-dir --upgrade pip \
+    && python3 -m pip install --no-cache-dir --upgrade setuptools wheel \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for security purposes
@@ -27,12 +33,6 @@ RUN if [ "${DOCKER_APP_USER}" != "root" ]; then \
 ENV VIRTUAL_ENV=${VIRTUAL_ENV}
 RUN python3 -m venv "${VIRTUAL_ENV}"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-
-RUN apt-get -qy update \
-    && apt-get -qqy install --no-install-recommends python3-wheel \
-    && python3 -m pip install --no-cache-dir --upgrade pip \
-    && python3 -m pip install --no-cache-dir --upgrade setuptools wheel \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN chown -R "${DOCKER_APP_USER}:${DOCKER_APP_USER}" /app
 USER ${DOCKER_APP_USER}


### PR DESCRIPTION
ensure's system python also has latest and patched setuptools etc. (scanned by trivy)