### PR TITLE
ci(docker): don't use `ENV DEBIAN_FRONTEND` nor install `apt-utils`

### DIFF
--- a/{{ cookiecutter.project_slug }}/Dockerfile
+++ b/{{ cookiecutter.project_slug }}/Dockerfile
@@ -9,15 +9,14 @@ ARG VIRTUAL_ENV=/app/venv
 ### General Python Debian Docker Best-Practice Preperation Steps ###
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
-ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
-RUN apt-get -qy update \
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get -qy update \
     && apt-get -qy upgrade \
-    && apt-get -qy install --no-install-recommends apt-utils tini \
+    && apt-get -qy install --no-install-recommends tini \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get -qy update \
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get -qy update \
     && apt-get -qqy install --no-install-recommends python3-wheel \
     && python3 -m pip install --no-cache-dir --upgrade pip \
     && python3 -m pip install --no-cache-dir --upgrade setuptools \


### PR DESCRIPTION
officially and actively discouraged:
https://serverfault.com/a/797318
https://stackoverflow.com/a/51023393/13953427

i've chosen to make it an local export instead of a per-apt-install 'ENV_VAR=value command' so that a) apt installs still are on same level and can be read like apt and other commands below and above it and b) don't have to worry thinking about if "this very apt install" one would want to write would require noninteractive mode (and if currently not, it may in a future update). 
In other words, this way the first and last line of an `RUN` containing apt always look the same (export, update -- clean, rm) and one can focus on within